### PR TITLE
Add option to disable the private task cache and add new tasks to the shared queue

### DIFF
--- a/libworkstream_df/configs/default-config.h
+++ b/libworkstream_df/configs/default-config.h
@@ -44,6 +44,11 @@
 #define WQEVENT_SAMPLING_TASKHISTFILE "task_histogram.gpdata"
 #define WQEVENT_SAMPLING_TASKLENGTHFILE "task_length.gpdata"
 
+// Disable workers local cache. A Task placed into this local cache cannot be
+// stolen by other workers. Static control program may temporarily stall until
+// the control program task finishes because of that.
+#define DISABLE_WQUEUE_LOCAL_CACHE 0
+
 //#define WS_PAPI_PROFILE
 //#define WS_PAPI_MULTIPLEX
 

--- a/libworkstream_df/work_distribution.c
+++ b/libworkstream_df/work_distribution.c
@@ -600,6 +600,7 @@ static wstream_df_frame_p work_steal(wstream_df_thread_p cthread, wstream_df_thr
   return fp;
 }
 
+#if !DISABLE_WQUEUE_LOCAL_CACHE
 static wstream_df_frame_p work_cache_take(wstream_df_thread_p cthread)
 {
   wstream_df_frame_p fp = NULL;
@@ -616,6 +617,7 @@ static wstream_df_frame_p work_cache_take(wstream_df_thread_p cthread)
 
   return fp;
 }
+#endif // !DISABLE_WQUEUE_LOCAL_CACHE
 
 static wstream_df_frame_p work_take(wstream_df_thread_p cthread)
 {
@@ -636,8 +638,10 @@ wstream_df_frame_p obtain_work(wstream_df_thread_p cthread,
   int level;
   wstream_df_frame_p fp = NULL;
 
+#if !DISABLE_WQUEUE_LOCAL_CACHE
   /* Try to obtain frame from the local cache */
   fp = work_cache_take(cthread);
+#endif // !DISABLE_WQUEUE_LOCAL_CACHE
 
   /* Try to obtain frame from the local work deque */
   if (fp == NULL)

--- a/libworkstream_df/wstream_df.c
+++ b/libworkstream_df/wstream_df.c
@@ -377,10 +377,15 @@ tdecrease_n (void *data, size_t n, bool is_write)
 	    }
 	}
 #endif
+#if DISABLE_WQUEUE_LOCAL_CACHE
+	cdeque_push_bottom (&cthread->work_deque,
+			    (wstream_df_type) fp);
+#else
       if (cthread->own_next_cached_thread != NULL)
 	cdeque_push_bottom (&cthread->work_deque,
 			    (wstream_df_type) cthread->own_next_cached_thread);
       cthread->own_next_cached_thread = fp;
+#endif
     }
 
   trace_state_restore(cthread);
@@ -1221,11 +1226,14 @@ void pre_main()
       wstream_df_worker_threads[i]->worker_id = i;
       wstream_df_worker_threads[i]->tsc_offset = 0;
       wstream_df_worker_threads[i]->tsc_offset_init = 0;
-      wstream_df_worker_threads[i]->own_next_cached_thread = NULL;
       wstream_df_worker_threads[i]->swap_barrier = NULL;
       wstream_df_worker_threads[i]->current_work_fn = NULL;
       wstream_df_worker_threads[i]->current_frame = NULL;
       wstream_df_worker_threads[i]->yield = 0;
+#if !DISABLE_WQUEUE_LOCAL_CACHE
+      wstream_df_worker_threads[i]->own_next_cached_thread = NULL;
+#endif // !DISABLE_WQUEUE_LOCAL_CACHE
+    
     }
 
   cpu_set_t cs;

--- a/libworkstream_df/wstream_df.h
+++ b/libworkstream_df/wstream_df.h
@@ -205,7 +205,9 @@ typedef struct __attribute__ ((aligned (64))) wstream_df_thread
   unsigned int worker_id;
 
   cdeque_t work_deque __attribute__((aligned (64)));
+#if !DISABLE_WQUEUE_LOCAL_CACHE
   wstream_df_frame_p own_next_cached_thread __attribute__((aligned (64)));
+#endif // !DISABLE_WQUEUE_LOCAL_CACHE
 
   unsigned int rands;
   unsigned int cpu;


### PR DESCRIPTION
When the synchronisation counter reaches zero, the task that decremented
the counter to zero puts the ready task into its local cache. This patch
allows the user to deactivate this cache with the
DISABLE_WQUEUE_LOCAL_CACHE variable in the config files.